### PR TITLE
Fix attributes not being caught properly

### DIFF
--- a/include/Hooks/Attributes.hpp
+++ b/include/Hooks/Attributes.hpp
@@ -11,11 +11,11 @@
 namespace Lapiz::Zenject::Internal {
     class Attributes {
         public:
-            static void FieldInfo_GetCustomAttributes(ArrayW<::System::Attribute*>& retval, System::Reflection::FieldInfo* self, System::Type* attributeType, bool inherit);
-            static void MethodInfo_GetCustomAttributes(ArrayW<::System::Attribute*>& retval, System::Reflection::MethodInfo* self, System::Type* attributeType, bool inherit);
+            static void FieldInfo_GetCustomAttributes(ArrayW<::System::Object*>& retval, System::Reflection::FieldInfo* self, System::Type* attributeType, bool inherit);
+            static void MethodInfo_GetCustomAttributes(ArrayW<::System::Object*>& retval, System::Reflection::MethodInfo* self, System::Type* attributeType, bool inherit);
         private:
             static bool DerivesFromInjectAttributeBase(System::Type* type);
-            static ArrayW<System::Attribute*> InsertCustomAttribute(::ArrayW<System::Attribute*> arr, System::Attribute* attribute);
+            static ArrayW<System::Object*> InsertCustomAttribute(::ArrayW<System::Object*> arr, System::Attribute* attribute);
             static System::Attribute* GetInjectAttribute(System::Reflection::MemberInfo* member);
     };
 }


### PR DESCRIPTION
Fixes the problem that attributes are not properly getting returned from the runtime field and method info when zenject asks for them