### PR TITLE
[1.35 Support] Bump dependencies, fix logging, remove removed fields

### DIFF
--- a/include/utilities/hooking.hpp
+++ b/include/utilities/hooking.hpp
@@ -8,39 +8,41 @@
 class Hooks
 {
 private:
-    inline static std::vector<void (*)(Logger& logger)> installFuncs;
+    inline static std::vector<void (*)()> installFuncs;
 
 public:
-    static void AddInstallFunc(void (*installFunc)(Logger& logger))
+    static void AddInstallFunc(void (*installFunc)())
     {
         installFuncs.push_back(installFunc);
     }
 
-    static inline void InstallHooks(Logger& logger)
+    static inline void InstallHooks()
     {
         for (auto& func : installFuncs)
-            func(logger);
+            func();
     }
 };
 
-#define AUTO_INSTALL_ORIG(name_)                                               \
-    struct Auto_Hook_##name_                                                   \
-    {                                                                          \
-        Auto_Hook_##name_()                                                    \
-        {                                                                      \
-            ::Hooks::AddInstallFunc(::Hooking::InstallOrigHook<Hook_##name_>); \
-        }                                                                      \
-    };                                                                         \
+#define AUTO_INSTALL_ORIG(name_)                                                                            \
+    struct Auto_Hook_##name_                                                                                \
+    {                                                                                                       \
+        static void Auto_Hook_##name_##_Install() {                                                         \
+            static constexpr auto logger = Paper::ConstLoggerContext(MOD_ID "_Install_" #name_);            \
+            ::Hooking::InstallOrigHook<Hook_##name_>(logger);                                               \
+        }                                                                                                   \
+        Auto_Hook_##name_() { ::Hooks::AddInstallFunc(Auto_Hook_##name_##_Install); }                       \
+    };                                                                                                      \
     static Auto_Hook_##name_ Auto_Hook_Instance_##name_;
 
-#define AUTO_INSTALL(name_)                                                \
-    struct Auto_Hook_##name_                                               \
-    {                                                                      \
-        Auto_Hook_##name_()                                                \
-        {                                                                  \
-            ::Hooks::AddInstallFunc(::Hooking::InstallHook<Hook_##name_>); \
-        }                                                                  \
-    };                                                                     \
+#define AUTO_INSTALL(name_)                                                                         \
+    struct Auto_Hook_##name_                                                                        \
+    {                                                                                               \
+        static void Auto_Hook_##name_##_Install() {                                                 \
+            static constexpr auto logger = Paper::ConstLoggerContext(MOD_ID "_Install_" #name_);    \
+            ::Hooking::InstallHook<Hook_##name_>(logger);                                           \
+        }                                                                                           \
+        Auto_Hook_##name_() { ::Hooks::AddInstallFunc(Auto_Hook_##name_##_Install); }               \
+    };                                                                                              \
     static Auto_Hook_##name_ Auto_Hook_Instance_##name_;
 
 #define MAKE_AUTO_HOOK_MATCH(name_, mPtr, retval, ...)                                                                                              \
@@ -52,7 +54,7 @@ public:
         static const MethodInfo* getInfo() { return ::il2cpp_utils::il2cpp_type_check::MetadataGetter<mPtr>::methodInfo(); }                        \
         static funcType* trampoline() { return &name_; }                                                                                            \
         static inline retval (*name_)(__VA_ARGS__) = nullptr;                                                                                       \
-        static funcType hook() { return hook_##name_; }                                                                                             \
+        static funcType hook() { return &::Hooking::HookCatchWrapper<&hook_##name_, funcType>::wrapper; }                                                                                             \
         static retval hook_##name_(__VA_ARGS__);                                                                                                    \
     };                                                                                                                                              \
     AUTO_INSTALL(name_)                                                                                                                             \
@@ -67,7 +69,7 @@ public:
         static const MethodInfo* getInfo() { return ::il2cpp_utils::il2cpp_type_check::MetadataGetter<mPtr>::methodInfo(); }                        \
         static funcType* trampoline() { return &name_; }                                                                                            \
         static inline retval (*name_)(__VA_ARGS__) = nullptr;                                                                                       \
-        static funcType hook() { return hook_##name_; }                                                                                             \
+        static funcType hook() { return &::Hooking::HookCatchWrapper<&hook_##name_, funcType>::wrapper; }                                                                                             \
         static retval hook_##name_(__VA_ARGS__);                                                                                                    \
     };                                                                                                                                              \
     AUTO_INSTALL_ORIG(name_)                                                                                                                        \

--- a/include/utilities/logging.hpp
+++ b/include/utilities/logging.hpp
@@ -5,17 +5,6 @@
 
 #include "paper/shared/logger.hpp"
 
-namespace Lapiz
-{
-    class Logging {
-        public:
-            static Logger& getLogger() {
-                static Logger* logger = new Logger({MOD_ID, VERSION, VERSION_LONG}, LoggerOptions(false, true));
-                return *logger;
-            }
-    };
-}
-
 template <> struct fmt::formatter<::StringW> : formatter<string_view> {
     // parse is inherited from formatter<string_view>.
     template <typename FormatContext>

--- a/mod.template.json
+++ b/mod.template.json
@@ -1,11 +1,11 @@
 {
-  "_QPVersion": "0.1.1",
+  "_QPVersion": "1.1.0",
   "name": "${mod_name}",
   "id": "${mod_id}",
   "author": "Raine",
   "version": "${version}",
   "packageId": "com.beatgames.beatsaber",
-  "packageVersion": "1.34.2_7115288407",
+  "packageVersion": "1.35.0_8016709773",
   "description": "Lapiz makes modders' lives easier by exposing utilities to them cleanly. This mod does nothing on its own.",
   "dependencies": [],
   "modFiles": [

--- a/qpm.json
+++ b/qpm.json
@@ -19,22 +19,22 @@
     },
     {
       "id": "beatsaber-hook",
-      "versionRange": "^5.0.0",
+      "versionRange": "^5.1.1",
       "additionalData": {}
     },
     {
       "id": "scotland2",
-      "versionRange": "^0.1.2",
+      "versionRange": "^0.1.4",
       "additionalData": {}
     },
     {
       "id": "bs-cordl",
-      "versionRange": "^3402.*",
+      "versionRange": "^3500.*",
       "additionalData": {}
     },
     {
       "id": "custom-types",
-      "versionRange": "^0.16.0",
+      "versionRange": "^0.17.0",
       "additionalData": {}
     },
     {

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -30,22 +30,22 @@
       },
       {
         "id": "beatsaber-hook",
-        "versionRange": "^5.0.0",
+        "versionRange": "^5.1.1",
         "additionalData": {}
       },
       {
         "id": "scotland2",
-        "versionRange": "^0.1.2",
+        "versionRange": "^0.1.4",
         "additionalData": {}
       },
       {
         "id": "bs-cordl",
-        "versionRange": "3402.*",
+        "versionRange": "3500.*",
         "additionalData": {}
       },
       {
         "id": "custom-types",
-        "versionRange": "^0.16.0",
+        "versionRange": "^0.17.0",
         "additionalData": {}
       },
       {
@@ -64,22 +64,22 @@
     {
       "dependency": {
         "id": "paper",
-        "versionRange": "=3.6.0",
+        "versionRange": "=3.6.1",
         "additionalData": {
-          "soLink": "https://github.com/Fernthedev/paperlog/releases/download/v3.6.0/libpaperlog.so",
-          "debugSoLink": "https://github.com/Fernthedev/paperlog/releases/download/v3.6.0/debug_libpaperlog.so",
+          "soLink": "https://github.com/Fernthedev/paperlog/releases/download/v3.6.1/libpaperlog.so",
+          "debugSoLink": "https://github.com/Fernthedev/paperlog/releases/download/v3.6.1/debug_libpaperlog.so",
           "overrideSoName": "libpaperlog.so",
-          "modLink": "https://github.com/Fernthedev/paperlog/releases/download/v3.6.0/paperlog.qmod",
-          "branchName": "version/v3_6_0",
+          "modLink": "https://github.com/Fernthedev/paperlog/releases/download/v3.6.1/paperlog.qmod",
+          "branchName": "version/v3_6_1",
           "compileOptions": {
             "systemIncludes": [
-              "shared/utfcpp"
+              "shared/utfcpp/source"
             ]
           },
           "cmake": false
         }
       },
-      "version": "3.6.0"
+      "version": "3.6.1"
     },
     {
       "dependency": {
@@ -94,13 +94,9 @@
     {
       "dependency": {
         "id": "custom-types",
-        "versionRange": "=0.16.16",
+        "versionRange": "=0.17.0",
         "additionalData": {
-          "soLink": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching/releases/download/v0.16.16/libcustom-types.so",
-          "debugSoLink": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching/releases/download/v0.16.16/debug_libcustom-types.so",
           "overrideSoName": "libcustom-types.so",
-          "modLink": "https://github.com/QuestPackageManager/Il2CppQuestTypePatching/releases/download/v0.16.16/CustomTypes.qmod",
-          "branchName": "version/v0_16_16",
           "compileOptions": {
             "cppFlags": [
               "-Wno-invalid-offsetof"
@@ -109,26 +105,26 @@
           "cmake": true
         }
       },
-      "version": "0.16.16"
+      "version": "0.17.0"
     },
     {
       "dependency": {
         "id": "sombrero",
-        "versionRange": "=0.1.37",
+        "versionRange": "=0.1.40",
         "additionalData": {
           "headersOnly": true,
-          "branchName": "version-v0.1.37"
+          "branchName": "version/v0_1_40"
         }
       },
-      "version": "0.1.37"
+      "version": "0.1.40"
     },
     {
       "dependency": {
         "id": "bs-cordl",
-        "versionRange": "=3402.1.2",
+        "versionRange": "=3500.0.0",
         "additionalData": {
           "headersOnly": true,
-          "branchName": "version/v3402_1_2",
+          "branchName": "version/v3500_0_0",
           "compileOptions": {
             "includePaths": [
               "include"
@@ -143,30 +139,33 @@
           }
         }
       },
-      "version": "3402.1.2"
+      "version": "3500.0.0"
     },
     {
       "dependency": {
         "id": "beatsaber-hook",
-        "versionRange": "=5.0.8",
+        "versionRange": "=5.1.1",
         "additionalData": {
-          "soLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.0.0/libbeatsaber-hook.so",
-          "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.0.0/debug_libbeatsaber-hook.so",
-          "branchName": "master",
+          "soLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.1.1/libbeatsaber-hook_5_1_1.so",
+          "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.1.1/debug_libbeatsaber-hook_5_1_1.so",
+          "branchName": "version/v5_1_1",
           "cmake": true
         }
       },
-      "version": "5.0.8"
+      "version": "5.1.1"
     },
     {
       "dependency": {
         "id": "scotland2",
-        "versionRange": "=0.1.3",
+        "versionRange": "=0.1.4",
         "additionalData": {
-          "overrideSoName": "libsl2.so"
+          "soLink": "https://github.com/sc2ad/scotland2/releases/download/v0.1.4/libsl2.so",
+          "debugSoLink": "https://github.com/sc2ad/scotland2/releases/download/v0.1.4/debug_libsl2.so",
+          "overrideSoName": "libsl2.so",
+          "branchName": "version/v0_1_4"
         }
       },
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     {
       "dependency": {

--- a/src/Hooks/objects/Redecoration.cpp
+++ b/src/Hooks/objects/Redecoration.cpp
@@ -37,7 +37,6 @@
 
 #include "GlobalNamespace/PlayersSpecificSettingsAtGameStartModel.hpp"
 #include "GlobalNamespace/IConnectedPlayer.hpp"
-#include "GlobalNamespace/EmptyDifficultyBeatmap.hpp"
 #include "GlobalNamespace/PracticeSettings.hpp"
 #include "GlobalNamespace/ColorScheme.hpp"
 #include "GlobalNamespace/ColorManager.hpp"
@@ -50,8 +49,6 @@
 #include "GlobalNamespace/BeatmapObjectManager.hpp"
 #include "GlobalNamespace/IBeatmapObjectSpawner.hpp"
 #include "GlobalNamespace/MultiplayerConnectedPlayerSongTimeSyncController.hpp"
-#include "GlobalNamespace/IBeatmapLevel.hpp"
-#include "GlobalNamespace/IDifficultyBeatmapSet.hpp"
 #include "GlobalNamespace/BeatmapCharacteristicSO.hpp"
 #include "GlobalNamespace/SaberManager.hpp"
 #include "GlobalNamespace/SaberTypeExtensions.hpp"
@@ -159,7 +156,6 @@ MAKE_AUTO_HOOK_ORIG_MATCH(BeatmapObjectsInstaller_InstallBindings, &BeatmapObjec
     auto orig_normalBasicNotePrefab = self->_normalBasicNotePrefab;
     auto orig_burstSliderHeadNotePrefab = self->_burstSliderHeadNotePrefab;
     auto orig_burstSliderNotePrefab = self->_burstSliderNotePrefab;
-    auto orig_burstSliderFillPrefab = self->_burstSliderFillPrefab;
     auto orig_bombNotePrefab = self->_bombNotePrefab;
     auto orig_obstaclePrefab = self->_obstaclePrefab;
     auto orig_sliderShortPrefab = self->_sliderShortPrefab;
@@ -173,7 +169,6 @@ MAKE_AUTO_HOOK_ORIG_MATCH(BeatmapObjectsInstaller_InstallBindings, &BeatmapObjec
     else self->_normalBasicNotePrefab = PREFAB_INITIALIZE(_normalBasicNotePrefab);
     self->_burstSliderHeadNotePrefab = PREFAB_INITIALIZE(_burstSliderHeadNotePrefab);
     self->_burstSliderNotePrefab = PREFAB_INITIALIZE(_burstSliderNotePrefab);
-    self->_burstSliderFillPrefab = PREFAB_INITIALIZE(_burstSliderFillPrefab);
     self->_bombNotePrefab = PREFAB_INITIALIZE(_bombNotePrefab);
     self->_obstaclePrefab = PREFAB_INITIALIZE(_obstaclePrefab);
     self->_sliderShortPrefab = PREFAB_INITIALIZE(_sliderShortPrefab);
@@ -190,7 +185,6 @@ MAKE_AUTO_HOOK_ORIG_MATCH(BeatmapObjectsInstaller_InstallBindings, &BeatmapObjec
     else self->_normalBasicNotePrefab = orig_normalBasicNotePrefab;
     self->_burstSliderHeadNotePrefab = orig_burstSliderHeadNotePrefab;
     self->_burstSliderNotePrefab = orig_burstSliderNotePrefab;
-    self->_burstSliderFillPrefab = orig_burstSliderFillPrefab;
     self->_bombNotePrefab = orig_bombNotePrefab;
     self->_obstaclePrefab = orig_obstaclePrefab;
     self->_sliderShortPrefab = orig_sliderShortPrefab;
@@ -246,7 +240,6 @@ MAKE_AUTO_HOOK_ORIG_MATCH(MultiplayerConnectedPlayerInstaller_InstallBindings, &
     auto orig_multiplayerGameNoteControllerPrefab = self->_multiplayerGameNoteControllerPrefab;
     auto orig_multiplayerBurstSliderHeadGameNoteControllerPrefab = self->_multiplayerBurstSliderHeadGameNoteControllerPrefab;
     auto orig_multiplayerBurstSliderGameNoteControllerPrefab = self->_multiplayerBurstSliderGameNoteControllerPrefab;
-    auto orig_multiplayerBurstSliderFillControllerPrefab = self->_multiplayerBurstSliderFillControllerPrefab;
     auto orig_multiplayerBombNoteControllerPrefab = self->_multiplayerBombNoteControllerPrefab;
     auto orig_multiplayerObstacleControllerPrefab = self->_multiplayerObstacleControllerPrefab;
 
@@ -256,7 +249,6 @@ MAKE_AUTO_HOOK_ORIG_MATCH(MultiplayerConnectedPlayerInstaller_InstallBindings, &
     self->_multiplayerGameNoteControllerPrefab = PREFAB_INITIALIZE(_multiplayerGameNoteControllerPrefab);
     self->_multiplayerBurstSliderHeadGameNoteControllerPrefab = PREFAB_INITIALIZE(_multiplayerBurstSliderHeadGameNoteControllerPrefab);
     self->_multiplayerBurstSliderGameNoteControllerPrefab = PREFAB_INITIALIZE(_multiplayerBurstSliderGameNoteControllerPrefab);
-    self->_multiplayerBurstSliderFillControllerPrefab = PREFAB_INITIALIZE(_multiplayerBurstSliderFillControllerPrefab);
     self->_multiplayerBombNoteControllerPrefab = PREFAB_INITIALIZE(_multiplayerBombNoteControllerPrefab);
     self->_multiplayerObstacleControllerPrefab = PREFAB_INITIALIZE(_multiplayerObstacleControllerPrefab);
 
@@ -269,7 +261,6 @@ MAKE_AUTO_HOOK_ORIG_MATCH(MultiplayerConnectedPlayerInstaller_InstallBindings, &
     self->_multiplayerGameNoteControllerPrefab = orig_multiplayerGameNoteControllerPrefab;
     self->_multiplayerBurstSliderHeadGameNoteControllerPrefab = orig_multiplayerBurstSliderHeadGameNoteControllerPrefab;
     self->_multiplayerBurstSliderGameNoteControllerPrefab = orig_multiplayerBurstSliderGameNoteControllerPrefab;
-    self->_multiplayerBurstSliderFillControllerPrefab = orig_multiplayerBurstSliderFillControllerPrefab;
     self->_multiplayerBombNoteControllerPrefab = orig_multiplayerBombNoteControllerPrefab;
     self->_multiplayerObstacleControllerPrefab = orig_multiplayerObstacleControllerPrefab;
 }
@@ -380,7 +371,6 @@ MAKE_AUTO_HOOK_ORIG_MATCH(FakeMirrorObjectsInstaller_InstallBindings, &FakeMirro
     auto orig_mirroredGameNoteControllerPrefab = self->_mirroredGameNoteControllerPrefab;
     auto orig_mirroredBurstSliderHeadGameNoteControllerPrefab = self->_mirroredBurstSliderHeadGameNoteControllerPrefab;
     auto orig_mirroredBurstSliderGameNoteControllerPrefab = self->_mirroredBurstSliderGameNoteControllerPrefab;
-    auto orig_mirroredBurstSliderFillControllerPrefab = self->_mirroredBurstSliderFillControllerPrefab;
     auto orig_mirroredBombNoteControllerPrefab = self->_mirroredBombNoteControllerPrefab;
     auto orig_mirroredObstacleControllerPrefab = self->_mirroredObstacleControllerPrefab;
     auto orig_mirroredSliderControllerPrefab = self->_mirroredSliderControllerPrefab;
@@ -389,7 +379,6 @@ MAKE_AUTO_HOOK_ORIG_MATCH(FakeMirrorObjectsInstaller_InstallBindings, &FakeMirro
     self->_mirroredGameNoteControllerPrefab = PREFAB_INITIALIZE(_mirroredGameNoteControllerPrefab);
     self->_mirroredBurstSliderHeadGameNoteControllerPrefab = PREFAB_INITIALIZE(_mirroredBurstSliderHeadGameNoteControllerPrefab);
     self->_mirroredBurstSliderGameNoteControllerPrefab = PREFAB_INITIALIZE(_mirroredBurstSliderGameNoteControllerPrefab);
-    self->_mirroredBurstSliderFillControllerPrefab = PREFAB_INITIALIZE(_mirroredBurstSliderFillControllerPrefab);
     self->_mirroredBombNoteControllerPrefab = PREFAB_INITIALIZE(_mirroredBombNoteControllerPrefab);
     self->_mirroredObstacleControllerPrefab = PREFAB_INITIALIZE(_mirroredObstacleControllerPrefab);
     self->_mirroredSliderControllerPrefab = PREFAB_INITIALIZE(_mirroredSliderControllerPrefab);
@@ -401,7 +390,6 @@ MAKE_AUTO_HOOK_ORIG_MATCH(FakeMirrorObjectsInstaller_InstallBindings, &FakeMirro
     self->_mirroredGameNoteControllerPrefab = orig_mirroredGameNoteControllerPrefab;
     self->_mirroredBurstSliderHeadGameNoteControllerPrefab = orig_mirroredBurstSliderHeadGameNoteControllerPrefab;
     self->_mirroredBurstSliderGameNoteControllerPrefab = orig_mirroredBurstSliderGameNoteControllerPrefab;
-    self->_mirroredBurstSliderFillControllerPrefab = orig_mirroredBurstSliderFillControllerPrefab;
     self->_mirroredBombNoteControllerPrefab = orig_mirroredBombNoteControllerPrefab;
     self->_mirroredObstacleControllerPrefab = orig_mirroredObstacleControllerPrefab;
     self->_mirroredSliderControllerPrefab = orig_mirroredSliderControllerPrefab;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ LAPIZ_EXPORT_FUNC void load() {
 
     INFO("Installing Zenject bindings and hooks..");
 
-    Hooks::InstallHooks(Lapiz::Logging::getLogger());
+    Hooks::InstallHooks();
     using namespace Lapiz::Zenject;
     auto zenjector = Zenjector::Get();
     zenjector->Install(Location::App, [](::Zenject::DiContainer* container){ container->BindInterfacesAndSelfTo<Lapiz::Utilities::MainThreadScheduler*>()->AsSingle(); });


### PR DESCRIPTION
- Hooking now uses paper logging
- Dependencies bumped
- fields that don't exist anymore removed from codebase
- removed unused / invalid includes