### PR TITLE
[Fix expose] Fix expose being used causing crashes

### DIFF
--- a/include/zenject/internal/Exposers/ExposerManager.hpp
+++ b/include/zenject/internal/Exposers/ExposerManager.hpp
@@ -1,51 +1,13 @@
 #pragma once
 
-#include "utilities/logging.hpp"
-#include "utilities/typeutil.hpp"
-
 #include "../ExposeSet.hpp"
 #include "Zenject/Context.hpp"
-#include "Zenject/SceneDecoratorContext.hpp"
-#include "Zenject/DiContainer.hpp"
-#include "Zenject/ConcreteIdBinderNonGeneric.hpp"
 #include "UnityEngine/MonoBehaviour.hpp"
-
+#include <set>
 
 namespace Lapiz::Zenject::Internal::Exposers {
     class ExposerManager {
         public:
-            void Install(Internal::ExposeSet* exposeSet, ::Zenject::Context* ctx, std::set<UnityEngine::MonoBehaviour*> iterlist) {
-                ::Zenject::SceneDecoratorContext* sceneDecoratorContext = il2cpp_utils::try_cast<::Zenject::SceneDecoratorContext>(ctx).value_or(nullptr);
-                if (!sceneDecoratorContext || !sceneDecoratorContext->m_CachedPtr) {
-                    return;
-                }
-
-                if (exposeSet->get_locationContractName() != sceneDecoratorContext->_decoratedContractName ||
-                    System::String::IsNullOrEmpty(sceneDecoratorContext->_decoratedContractName) ||
-                    exposeSet->get_locationContractName().empty()) {
-                    return;
-                }
-
-                if (iterlist.size() == 0) {
-                    ListW<UnityEngine::MonoBehaviour*> injectables(sceneDecoratorContext->_injectableMonoBehaviours);
-                    iterlist.insert(injectables.begin(), injectables.end());
-                }
-
-                UnityEngine::MonoBehaviour* toExpose = nullptr;
-                for (auto il : iterlist) {
-                    if (il->klass == exposeSet->get_typeToExpose()) {
-                        toExpose = il;
-                        break;
-                    }
-                }
-
-                if (toExpose && toExpose->m_CachedPtr) {
-                    auto t = il2cpp_utils::GetSystemType(exposeSet->get_typeToExpose());
-                    sceneDecoratorContext->get_Container()->Bind(t)->FromInstance(toExpose)->AsSingle();
-                }
-                else {
-                    WARNING("Could not find {} in {}.", exposeSet->get_typeToExpose()->name, exposeSet->get_locationContractName());
-                }
-            };
+            void Install(Internal::ExposeSet* exposeSet, ::Zenject::Context* ctx, std::set<UnityEngine::MonoBehaviour*> iterlist);
     };
 }

--- a/include/zenject/internal/Mutators/MutatorManager.hpp
+++ b/include/zenject/internal/Mutators/MutatorManager.hpp
@@ -1,48 +1,12 @@
 #pragma once
 
-#include "utilities/logging.hpp"
-#include "utilities/typeutil.hpp"
-
 #include "../MutateSet.hpp"
-#include "Zenject/Context.hpp"
-#include "Zenject/SceneDecoratorContext.hpp"
-#include "Zenject/Context.hpp"
 #include "UnityEngine/MonoBehaviour.hpp"
 
 
 namespace Lapiz::Zenject::Internal::Mutators {
     class MutatorManager {
         public:
-            void Install(Internal::MutateSet* mutateSet, ::Zenject::Context* ctx, std::set<UnityEngine::MonoBehaviour*> iterlist) {
-                ::Zenject::SceneDecoratorContext* sceneDecoratorContext = il2cpp_utils::try_cast<::Zenject::SceneDecoratorContext>(ctx).value_or(nullptr);
-                if (!sceneDecoratorContext || !sceneDecoratorContext->m_CachedPtr) {
-                    return;
-                }
-
-                if (mutateSet->get_locationContractName() != sceneDecoratorContext->_decoratedContractName ||
-                    System::String::IsNullOrEmpty(sceneDecoratorContext->_decoratedContractName) ||
-                    mutateSet->get_locationContractName().empty()) {
-                    return;
-                }
-
-                if (iterlist.size() == 0) {
-                    ListW<UnityEngine::MonoBehaviour*> injectables(sceneDecoratorContext->_injectableMonoBehaviours);
-                    iterlist.insert(injectables.begin(), injectables.end());
-                }
-
-                UnityEngine::MonoBehaviour* toMutate = nullptr;
-                for (auto il : iterlist) {
-                    if (il->klass == mutateSet->get_typeToMutate()) {
-                        toMutate = il;
-                        break;
-                    }
-                }
-
-                if (toMutate && toMutate->m_CachedPtr) {
-                    mutateSet->get_onMutate()->Invoke(sceneDecoratorContext, toMutate);
-                } else {
-                    WARNING("Could not find {} in {}.", mutateSet->get_typeToMutate()->name, mutateSet->get_locationContractName());
-                }
-            };
+            void Install(Internal::MutateSet* mutateSet, ::Zenject::Context* ctx, std::set<UnityEngine::MonoBehaviour*> iterlist);
     };
 }

--- a/src/zenject/ExposerManager.cpp
+++ b/src/zenject/ExposerManager.cpp
@@ -1,0 +1,46 @@
+#include "zenject/internal/Exposers/ExposerManager.hpp"
+
+#include "utilities/logging.hpp"
+#include "utilities/typeutil.hpp"
+#include "Zenject/SceneDecoratorContext.hpp"
+#include "Zenject/DiContainer.hpp"
+#include "Zenject/ConcreteIdBinderNonGeneric.hpp"
+
+namespace Lapiz::Zenject::Internal::Exposers {
+    void ExposerManager::Install(Internal::ExposeSet* exposeSet, ::Zenject::Context* ctx, std::set<UnityEngine::MonoBehaviour*> iterlist) {
+        auto sceneDecoratorContext = il2cpp_utils::try_cast<::Zenject::SceneDecoratorContext>(ctx).value_or(nullptr);
+        if (!sceneDecoratorContext || !sceneDecoratorContext->m_CachedPtr) {
+            return;
+        }
+
+        if (exposeSet->get_locationContractName() != sceneDecoratorContext->_decoratedContractName ||
+            System::String::IsNullOrEmpty(sceneDecoratorContext->_decoratedContractName) ||
+            exposeSet->get_locationContractName().empty()) {
+            return;
+        }
+
+        if (iterlist.size() == 0) {
+            auto count = sceneDecoratorContext->_injectableMonoBehaviours->Count;
+            for (auto i = 0; i < count; i++) {
+                iterlist.insert(sceneDecoratorContext->_injectableMonoBehaviours->get_Item(i));
+            }
+        }
+
+        UnityEngine::MonoBehaviour* toExpose = nullptr;
+        for (auto il : iterlist) {
+            if (il->klass == exposeSet->get_typeToExpose()) {
+                toExpose = il;
+                break;
+            }
+        }
+
+        if (toExpose && toExpose->m_CachedPtr) {
+            ArrayW<System::Type*> ts(il2cpp_array_size_t(1));
+            ts[0] = reinterpret_cast<System::Type*>(il2cpp_utils::GetSystemType(exposeSet->get_typeToExpose()));
+            sceneDecoratorContext->Container->Bind(ts)->FromInstance(toExpose)->AsSingle();
+        }
+        else {
+            WARNING("Could not find {} in {}.", exposeSet->get_typeToExpose()->name, exposeSet->get_locationContractName());
+        }
+    };
+}

--- a/src/zenject/MutatorManager.cpp
+++ b/src/zenject/MutatorManager.cpp
@@ -1,0 +1,43 @@
+#include "zenject/internal/Mutators/MutatorManager.hpp"
+
+#include "utilities/logging.hpp"
+#include "utilities/typeutil.hpp"
+#include "Zenject/Context.hpp"
+#include "Zenject/SceneDecoratorContext.hpp"
+#include "Zenject/Context.hpp"
+
+namespace Lapiz::Zenject::Internal::Mutators {
+    void MutatorManager::Install(Internal::MutateSet* mutateSet, ::Zenject::Context* ctx, std::set<UnityEngine::MonoBehaviour*> iterlist) {
+        ::Zenject::SceneDecoratorContext* sceneDecoratorContext = il2cpp_utils::try_cast<::Zenject::SceneDecoratorContext>(ctx).value_or(nullptr);
+        if (!sceneDecoratorContext || !sceneDecoratorContext->m_CachedPtr) {
+            return;
+        }
+
+        if (mutateSet->get_locationContractName() != sceneDecoratorContext->_decoratedContractName ||
+            System::String::IsNullOrEmpty(sceneDecoratorContext->_decoratedContractName) ||
+            mutateSet->get_locationContractName().empty()) {
+            return;
+        }
+
+        if (iterlist.size() == 0) {
+            auto count = sceneDecoratorContext->_injectableMonoBehaviours->Count;
+            for (auto i = 0; i < count; i++) {
+                iterlist.insert(sceneDecoratorContext->_injectableMonoBehaviours->get_Item(i));
+            }
+        }
+
+        UnityEngine::MonoBehaviour* toMutate = nullptr;
+        for (auto il : iterlist) {
+            if (il->klass == mutateSet->get_typeToMutate()) {
+                toMutate = il;
+                break;
+            }
+        }
+
+        if (toMutate && toMutate->m_CachedPtr) {
+            mutateSet->get_onMutate()->Invoke(sceneDecoratorContext, toMutate);
+        } else {
+            WARNING("Could not find {} in {}.", mutateSet->get_typeToMutate()->name, mutateSet->get_locationContractName());
+        }
+    };
+}


### PR DESCRIPTION
Fix for expose crashing, not sure what caused it to crash in the first place but now using expose seems to be working (tested with `zenjector->Expose<GlobalNamespace::CoreGameHUDController*>("Environment");`)