### PR TITLE
Set `isLibrary` to true

### DIFF
--- a/mod.template.json
+++ b/mod.template.json
@@ -3,6 +3,7 @@
   "name": "${mod_name}",
   "id": "${mod_id}",
   "author": "Raine",
+  "isLibrary": true,
   "version": "${version}",
   "packageId": "com.beatgames.beatsaber",
   "packageVersion": "1.37.1_9895289101",


### PR DESCRIPTION
Lapiz does nothing on its own. `isLibrary` tells the mod manager to remove the qmod if there are no mods referencing it.